### PR TITLE
feat: configure autoprefixer for css

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,22 @@
   "dependencies": {
     "primeflex": "^3.3.0",
     "primevue": "^3.27.0"
-  }
+  },
+  "browserslist": [
+    ">0.3%",
+    "not ie 11",
+    "not dead",
+    "not op_mini all",
+    "last 3 version",
+    "Chrome >= 35",
+    "Firefox >= 38",
+    "Edge >= 10",
+    "Explorer >= 10",
+    "ie >= 10",
+    "iOS >= 8",
+    "Safari >= 8",
+    "Android 2.3",
+    "Android >= 4",
+    "Opera >= 12"
+  ]
 }


### PR DESCRIPTION
Configure autoprefixer. (A plugin to add `-webkit`, `-moz`, `-ms` and etc. to css)

https://autoprefixer.github.io/